### PR TITLE
Fix issues in the fullstack-nosql template

### DIFF
--- a/fullstack-nosql/.env.example
+++ b/fullstack-nosql/.env.example
@@ -1,0 +1,3 @@
+# secret for credential
+TENCENT_SECRET_ID=xxx
+TENCENT_SECRET_KEY=xxx

--- a/fullstack-nosql/README.md
+++ b/fullstack-nosql/README.md
@@ -50,7 +50,9 @@ TENCENT_SECRET_KEY=123
 >    [API 密钥管理](https://console.cloud.tencent.com/cam/capi)  中获
 >    取**SecretId**和**SecretKey**。
 
-3.在 `backend/src` 文件夹目录下，通过以下命令安装所需依赖：
+3. [开通腾讯云开发环境](https://console.cloud.tencent.com/tcb/env/index)
+
+4. 在 `backend/src` 文件夹目录下，通过以下命令安装所需依赖：
 
 ```bash
 $ npm install

--- a/fullstack-nosql/backend/serverless.yml
+++ b/fullstack-nosql/backend/serverless.yml
@@ -24,7 +24,7 @@ inputs:
           protocols:
             - http
             - https
-          serviceName:
+          serviceName: fullstackNoSQLBackend
           description: The service of Serverless Framework - MongoDB
           environment: release
           endpoints:


### PR DESCRIPTION
fix #39 

- [x] No `.env.example` file
- [x] User need to setup ”云开发“ 
- [x] Empty `serviceName` in `serverless.yml`
