### PR TITLE
Remove prod publish for multi-scf-starter

### DIFF
--- a/.github/workflows/multi-scf-starter.yml
+++ b/.github/workflows/multi-scf-starter.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           cd multi-scf-starter
           SERVERLESS_PLATFORM_STAGE=dev sls publish
-          sls publish
       - name: Test template
         run: |
           sls init multi-scf-starter --name test-multi-scf-starter


### PR DESCRIPTION
通过查看prod redis的数据，在prod上这个template不是由ci的账号发布的，所以ci不能发布template到prod